### PR TITLE
Replace deprecated method

### DIFF
--- a/options_logged_info.js
+++ b/options_logged_info.js
@@ -4,7 +4,10 @@ const URL = 'https://api.solved.ac/validate_token.php'
 
 const logout = () => {
 	chrome.storage.local.remove('token', () => {
-		chrome.tabs.getSelected(null, ({ id }) => {
+		chrome.tabs.query({
+			active: true,
+			currentWindow: true
+		}, ({ id }) => {
 			const code = 'window.location.reload();'
 			chrome.tabs.executeScript(id, { code })
 		})

--- a/options_login.js
+++ b/options_login.js
@@ -17,7 +17,10 @@ const validate = () => {
 			const { token } = data
 			console.log(token)
 			chrome.storage.local.set({ token }, () => {
-				chrome.tabs.getSelected(null, ({ id }) => {
+				chrome.tabs.query({
+					active: true,
+					currentWindow: true
+				}, ({ id }) => {
 					const code = 'window.location.reload();'
 					chrome.tabs.executeScript(id, { code })
 				})


### PR DESCRIPTION
`chrome.tabs.getSelected`는 deprecated되었으며, 크롬 외 브라우저에선 지원하지 않습니다. 따라서 이를 `chrome.tabs.query`으로 수정했습니다.