### PR TITLE
Add expect tier display function for non-members

### DIFF
--- a/src/content/main.js
+++ b/src/content/main.js
@@ -239,19 +239,51 @@ async function addLevelIndicators() {
     if (isUserPage()) {
         var userId = document.querySelector(".page-header h1").innerText.trim()
         var userStaticsTable = document.querySelector("#statics tbody")
-
+        const isShowUserTempTier = JSON.parse(await getPrefs('show_userpage_temp_tier', 'false'))
         const userData = await (await fetch("https://api.solved.ac/user_information.php?id=" + userId)).json()
-        if (!userData) return
 
+        if (!userData &&!isShowUserTempTier) return
+        
         var newRow = document.createElement("tr")
         var newRowHeader = document.createElement("th")
-        newRowHeader.innerText = "solved.ac"
         var newRowDescription = document.createElement("td")
-        newRowDescription.innerHTML = "<a href=\"https://solved.ac/" + userData.user_id + "\">"
-                                        + "<span class=\"text-" + levelCssClass(userData.level) + "\">"
-                                            + levelLabel(userData.level) + "<b>" + userData.user_id + "</b>"
-                                        + "</span>"
-                                        + "</a>"
+
+        if(!userData && isShowUserTempTier)
+        {
+            var acceptPanel = document.querySelector(".panel.panel-default")
+            var acceptProblems = acceptPanel.querySelectorAll(".problem_number>a")
+            var totalExpPoint = 0
+            var promises = [];
+
+            for(i = 0; i< acceptProblems.length;i++){
+                var problemId = acceptProblems[i].textContent;
+                promises[i] = fetch("https://api.solved.ac/problem_level.php?id=" + problemId)
+            }
+            
+            responses = await Promise.all(promises);
+            for(i = 0;i<responses.length;i++){
+                data = await responses[i].json()
+                totalExpPoint+= getExpPointFromLevel(data.level)
+            }
+
+            var expectLevel = getExpectLevelFromExpPoint(totalExpPoint)
+            newRowHeader.innerText = "solved.ac 임시티어"
+            newRowDescription.innerHTML = "<a href=\"https://boj.com/" + userId + "\">"
+            + "<span class=\"text-" + levelCssClass(expectLevel) + "\">"
+                + levelLabel(expectLevel) + "<b>" +userId + "</b>"
+            + "</span>"
+            + "</a>"
+        }
+        else
+        {
+            newRowHeader.innerText = "solved.ac"
+            newRowDescription.innerHTML = "<a href=\"https://solved.ac/" + userData.user_id + "\">"
+            + "<span class=\"text-" + levelCssClass(userData.level) + "\">"
+                + levelLabel(userData.level) + "<b>" + userData.user_id + "</b>"
+            + "</span>"
+            + "</a>"
+        }
+
         newRow.appendChild(newRowHeader)
         newRow.appendChild(newRowDescription)
         userStaticsTable.appendChild(newRow)

--- a/src/content/utils.js
+++ b/src/content/utils.js
@@ -104,3 +104,24 @@ function algorithmToTag(item, showTagsInEnglish) {
         }
     }
 }
+
+function getExpPointFromLevel(level){
+    const levelData = [320, 480, 912, 1642, 2791, 4465, 6698, 9913, 14472, 20840, 29593, 
+                       41431, 57588, 79472, 108877, 148072, 200638, 270862, 364309, 488174, 
+                       651712, 866777, 1148479, 1515993, 1993531, 2611525, 3408040, 4430452,
+                       5737436, 7401292, 9510661]
+    return levelData[level]
+}
+
+function getExpectLevelFromExpPoint(exp){
+    const expTable = [0, 4800, 15740, 38720, 83400, 163700, 298000, 785400, 1202800, 1795000, 2834700,
+                      4276000, 6261000, 8982000, 12704000, 18796000, 26842000, 37941000, 52792000, 
+                      720000000, 152000000, 213000000, 294000000, 380000000, 639000000, 1000000000, 
+                      1200000000, 1500000000]
+    for(i=0;i<expTable.length-1;i++){
+        if(expTable[i] < exp && exp < expTable[i+1])
+            return i+1;
+    }
+    if(exp>expTable[expTable.length-1])
+        return expTable.length
+}

--- a/src/options/options_logged_info.html
+++ b/src/options/options_logged_info.html
@@ -41,6 +41,16 @@
                 <span class="toggle_knob"></span>
             </span>
         </div>
+        
+        <div class="option_item" data-key="show_userpage_temp_tier">
+            <span class="option_caption">
+                유저페이지 임시티어 보기
+            </span>
+            <span class="option_switch">
+                <span class="toggle_knob"></span>
+            </span>
+        </div>
+
 	</div>
 	<script src="/3rdparty/axios.0.19.0.min.js"></script>
     <script src="/src/options/options_logged_info.js"></script>

--- a/src/options/options_login.html
+++ b/src/options/options_login.html
@@ -46,6 +46,14 @@
                 <span class="toggle_knob"></span>
             </span>
         </div>
+        <div class="option_item" data-key="show_userpage_temp_tier">
+            <span class="option_caption">
+                유저페이지 임시티어 보기
+            </span>
+            <span class="option_switch">
+                <span class="toggle_knob"></span>
+            </span>
+        </div>
 	</div>
 	<script src="/3rdparty/axios.0.19.0.min.js"></script>
     <script src="/src/options/options_login.js"></script>


### PR DESCRIPTION
Before this function implemented, user cannot know where they are
and what are the proper problems without tier

This function works following steps

1. Parse the solved problem in user page
2. Get Level information from Api server
3. Calculate the total exp point from level information
4. Display expectation tier

Thanks 
Seokho.
